### PR TITLE
FSM graphs and process pseudocode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,5 @@ data
 *pyc
 
 # Standalone tex img files
-img/moran_process.pdf
+img/moran_process.pd
+tex/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ data
 
 # Standalone tex img files
 img/moran_process.pdf
+tex/*.pdf

--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,5 @@ data
 *pyc
 
 # Standalone tex img files
-img/moran_process.pd
+img/moran_process.pdf
 tex/*.pdf

--- a/tex/fortress_3.tex
+++ b/tex/fortress_3.tex
@@ -1,0 +1,30 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\usepackage{standalone}
+\usetikzlibrary{calc}
+
+\begin{document}
+
+    \begin{tikzpicture}
+
+    \tikzstyle{state}=[minimum width=0.5cm, font=\boldmath];
+
+    \node[circle, draw=black, thick]  (1) at (0,0) [state] {$1$};
+    \node[circle, draw=black, thick] (2) at ($(1)+(0,-3)$) [state] {$2$}; 
+    \node[circle, draw=black, thick]  (3) at ($(2)+(3,0)$) [state] {$3$};
+
+    \coordinate[above of=1] (s);
+
+    \draw (s) edge[out=-90, in=90, ->, thick] node [above right] {$D$} (1);
+
+    \draw (1) edge[out=180, in=135, loop, thick] node [above left] {$C/D$} (1);
+    \draw (3) edge[out=0, in=45, loop, thick] node [right] {$C/C$} (3);
+
+    \draw (1) edge[out=-135, in=135, ->, thick] node [left] {$C/D$} (2);
+    \draw (2) edge[out=45,in=-45,->,thick] node [right] {$D/C$} (1);
+    \draw (2) edge[out=0,in=180,->,thick] node [below] {$D/C$} (3);
+    \draw (3) edge[out=90,in=0,->,thick] node [above right] {$D/D$} (1);
+    \end{tikzpicture}
+
+\end{document}

--- a/tex/fortress_4.tex
+++ b/tex/fortress_4.tex
@@ -1,0 +1,33 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\usepackage{standalone}
+\usetikzlibrary{calc}
+
+\begin{document}
+
+    \begin{tikzpicture}
+
+    \tikzstyle{state}=[minimum width=0.5cm, font=\boldmath];
+
+    \node[circle, draw=black, thick]  (1) at (0,0) [state] {$1$};
+    \node[circle, draw=black, thick]  (4) at ($(1)+(4,0)$) [state] {$4$};
+    \node[circle, draw=black, thick] (2) at ($(1)+(0,-4)$) [state] {$2$}; 
+    \node[circle, draw=black, thick]  (3) at ($(2)+(4,0)$) [state] {$3$};
+
+    \coordinate[above of=1] (s);
+
+    \draw (s) edge[out=-90, in=90, ->, thick] node [above right] {$D$} (1);
+
+    \draw (1) edge[out=180, in=135, loop, thick] node [above left] {$C/D$} (1);
+    \draw (4) edge[out=0, in=45, loop, thick] node [right] {$C/C$} (4);
+
+    \draw (1) edge[out=-135, in=135, ->, thick] node [left] {$D/D$} (2);
+    \draw (2) edge[out=45,in=-45,->,thick] node [right] {$C/D$} (1);
+    \draw (2) edge[out=0,in=180,->,thick] node [below] {$D/D$} (3);
+    \draw (4) edge[out=180,in=0,->,thick] node [above] {$D/D$} (1);
+    \draw (3) edge[out=45,in=-45,->,thick] node [right] {$D/C$} (4);
+    \draw (3) edge[out=90,in=-20,->,thick] node [above right] {$C/D$} (1);
+    \end{tikzpicture}
+
+\end{document}

--- a/tex/fsm_one.tex
+++ b/tex/fsm_one.tex
@@ -1,0 +1,87 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\usepackage{standalone}
+\usetikzlibrary{calc}
+
+\begin{document}
+    \begin{tikzpicture}
+
+    \tikzstyle{state}=[minimum width=0.8cm, font=\boldmath];
+    \node[circle, draw=black, thick] (5) at (0, 0) [state] {$6$};
+	\node[circle, draw=black, thick] (2) at (4, 0) [state] {$3$};
+	\node[circle, draw=black, thick] (15) at (-2, -2) [state] {$16$};
+	\node[circle, draw=black, thick] (8) at ($(2)+(2,-2)$) [state] {$9$};
+	\node[circle, draw=black, thick] (10) at ($(15)+(4, 0)$) [state] {$11$};
+	
+	\node[circle, draw=black, thick] (7) at ($(5)+(-1,-4)$) [state] {$8$};
+	\node[circle, draw=black, thick] (11) at ($(7)+(2, 0)$) [state] {$12$};
+
+
+
+	\node[circle, draw=black, thick] (9) at ($(10)+(0,-4)$) [state] {$10$};
+	\node[circle, draw=black, thick] (0) at ($(9)+(-5,0)$) [state] {$1$};
+	\node[circle, draw=black, thick] (14) at ($(9)+(5,0)$) [state] {$15$};
+
+	\node[circle, draw=black, thick] (1) at ($(0)+(0,-2)$) [state] {$2$};
+	\node[circle, draw=black, thick] (4) at ($(1)+(2,0)$) [state] {$5$};
+	\node[circle, draw=black, thick] (6) at ($(4)+(4,0)$) [state] {$7$};
+	\node[circle, draw=black, thick] (13) at ($(6)+(2,0)$) [state] {$14$};
+
+	\node[circle, draw=black, thick] (3) at ($(4)+(0,-2)$) [state] {$4$};
+	\node[circle, draw=black, thick] (12) at ($(6)+(0,-2)$) [state] {$13$};
+
+
+    \coordinate[left of=0] (s);
+
+    \draw (s) edge[out=0, in=180, ->, thick] node [above] {$C$} (0);
+    \draw (0) edge[out=90, in=135, ->, thick] node [above left] {$C/C$} (7);
+    \draw (0) edge[out=-90, in=90, ->, thick] node [left] {$D/C$} (1);
+
+    \draw (1) edge[out=45, in=-135, ->, thick] node [left] {$C/D$} (11);
+    \draw (1) edge[out=45, in=-135, ->, thick] node [right] {$D/D$} (11);
+    
+    \draw (2) edge[out=-45, in=135, ->, thick] node [above right] {$C/D$} (8);
+    \draw (2) edge[out=-45, in=135, ->, thick] node [below left] {$D/C$} (8);
+
+    \draw (3) edge[out=180, in=135, ->, thick, loop] node [left] {$C/C$} (3);
+    \draw (3) edge[out=0, in=180, ->, thick] node [below] {$D/D$} (12);
+
+    \draw (4) edge[out=0, in=180, ->, thick] node [above] {$C/C$} (6);
+    \draw (4) edge[out=-90, in=90, ->, thick] node [left] {$D/C$} (3);
+
+    \draw (5) edge[out=0, in=180, ->, thick] node [below, yshift=-1cm, xshift=2cm] {$D/D$} (8);
+    \draw (5) edge[out=-45, in=90, ->, thick] node [left, yshift=-0.8cm, xshift=-0.3cm, rotate=90] {$C/C$} (11);
+
+    \draw (6) edge[out=0, in=180, ->, thick] node [below] {$C/D$} (13);
+    \draw (6) edge[out=45, in=180, ->, thick] node [above] {$D/C$} (14);
+
+    \draw (7) edge[out=-135, in=135, ->, thick] node [yshift=1.8cm] {$C/D$} (4);
+    \draw (7) edge[out=45, in=180, ->, thick] node [above, yshift=1.2cm, xshift=1.8cm] {$D/D$} (2);
+
+    \draw (8) edge[out=0, in=45, ->, thick, loop] node [above] {$D/D$} (8);
+    \draw (8) edge[out=-90, in=130, ->, thick] node [right] {$C/D$} (14);
+
+    \draw (9) edge[out=-135, in=-45, ->, thick] node [above] {$C/C$} (0);
+    \draw (9) edge[out=100, in=-100, ->, thick] node [above left, yshift=1.5cm, rotate=90] {$D/D$} (10);
+
+    \draw (10) edge[out=0, in=180, ->, thick] node [below left, xshift=-0.5cm] {$C/C$} (8);
+    \draw (10) edge[out=180, in=0, ->, thick] node [above left, xshift=-0.5cm] {$D/C$} (15);
+
+    \draw (11) edge[out=0, in=70, ->, thick] node [above right] {$C/D$} (6);
+    \draw (11) edge[out=155, in=-90, ->, thick] node [right, yshift=1cm] {$D/D$} (5);
+
+    \draw (12) edge[out=90, in=-90, ->, thick] node [above right] {$C/D$} (6);
+    \draw (12) edge[out=155, in=-90, ->, thick] node [left, yshift=-1cm] {$D/D$} (9);
+
+    \draw (13) edge[out=135, in=0, ->, thick] node [below left, xshift=-0.4cm, yshift=0.4cm] {$C/D$} (9);
+    \draw (13) edge[out=70, in=-135, ->, thick] node [right] {$D/D$} (8);
+
+    \draw (14) edge[out=70, in=-45, ->, thick] node [right] {$C/D$} (8);
+    \draw (14) edge[out=-90, in=0, ->, thick] node [right] {$D/D$} (13);
+
+    \draw (15) edge[out=-45, in=30, ->, thick] node [left, xshift=-1.8cm, yshift=2.5cm] {$C/C$} (4);
+    \draw (15) edge[out=90, in=180, ->, thick] node [above left] {$D/C$} (5);
+
+    \end{tikzpicture}
+\end{document}

--- a/tex/fsm_three.tex
+++ b/tex/fsm_three.tex
@@ -1,0 +1,47 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\usepackage{standalone}
+\usetikzlibrary{calc}
+
+\begin{document}
+
+    \begin{tikzpicture}
+
+    \tikzstyle{state}=[minimum width=0.5cm, font=\boldmath];
+
+    \node[circle, draw=black, thick]  (0) at (0,0) [state] {$1$};
+    \node[circle, draw=black, thick]  (1) at ($(0)+(0,2)$) [state] {$2$};
+    \node[circle, draw=black, thick]  (2) at ($(1)+(2,1.5)$) [state] {$3$}; 
+    \node[circle, draw=black, thick]  (3) at ($(2)+(3,0)$) [state] {$4$};
+    \node[circle, draw=black, thick]  (4) at ($(1)+(8,0)$) [state] {$5$};  
+    \node[circle, draw=black, thick]  (5) at ($(0)+(8,0)$) [state] {$6$};
+    \node[circle, draw=black, thick]  (6) at ($(3)+(0,-4.5)$) [state] {$7$};
+    \node[circle, draw=black, thick]  (7) at ($(2)+(0,-4.5)$) [state] {$8$}; 
+
+    \coordinate[left of=0] (s);
+
+    \draw (s) edge[out=0, in=180, ->, thick] node [above] {$C$} (0);
+
+    \draw (0) edge[out=-45, in=-100, loop, thick] node [below] {$C/C$} (0);
+    \draw (6) edge[out=-45, in=-100, loop, thick] node [below] {$C/D$} (6);
+    \draw (6) edge[out=190, in=135, loop, thick] node [below, yshift=-0.5cm] {$D/D$} (6);
+    \draw (7) edge[out=190, in=135, loop, thick] node [above, xshift=1cm] {$C/D$} (7);
+    \draw (2) edge[out=190, in=135, loop, thick] node [left] {$D/D$} (2);
+
+    \draw (2) edge[out=0,in=180,->,thick] node [above] {$C/C$} (3);
+    \draw (3) edge[out=-35,in=170,->,thick] node [above right] {$C/D$} (4);
+    \draw (5) edge[out=-135,in=0,->,thick] node [below] {$C/C$} (6);
+
+    \draw (0) edge[out=45,in=-135,->,thick] node [above, rotate=45, xshift=2cm, yshift=-0.5cm] {$D/C$} (3);
+
+    \draw (1) edge[out=-45,in=180,->,thick] node [below right, xshift=2cm] {$C/D$} (5);
+    \draw (1) edge[out=-135,in=135,->,thick] node [left] {$D/C$} (0);
+    \draw (3) edge[out=-90,in=90,->,thick] node [above, rotate=90] {$D/D$} (6);
+    \draw (4) edge[out=90,in=0,->,thick] node [above] {$C/C$} (3);
+    \draw (4) edge[out=180,in=0,->,thick] node [above left, xshift=-2.5cm] {$D/D$} (1);
+    \draw (5) edge[out=135,in=-45,->,thick] node [below, rotate=-45] {$D/D$} (3);
+    \draw (7) edge[out=-90,in=-90,->,thick] node [below] {$D/C$} (5);
+    \end{tikzpicture}
+
+\end{document}

--- a/tex/fsm_two.tex
+++ b/tex/fsm_two.tex
@@ -1,0 +1,87 @@
+\documentclass{standalone}
+
+\usepackage{tikz}
+\usepackage{standalone}
+\usetikzlibrary{calc}
+
+\begin{document}
+    \begin{tikzpicture}
+
+    \tikzstyle{state}=[minimum width=0.8cm, font=\boldmath];
+    \node[circle, draw=black, thick] (1) at (0, 0) [state] {$2$};
+	\node[circle, draw=black, thick] (4) at (4, 0) [state] {$5$};
+
+	\node[circle, draw=black, thick] (5) at (-2, -1) [state] {$6$};
+    \node[circle, draw=black, thick] (6) at (2, -1) [state] {$7$};
+    \node[circle, draw=black, thick] (3) at ($(5)+(-1,-2)$) [state] {$4$};
+    \node[circle, draw=black, thick] (12) at ($(5)+(0,-4)$) [state] {$13$};
+    \node[circle, draw=black, thick] (8) at ($(12)+(0,-2)$) [state] {$9$};
+    \node[circle, draw=black, thick] (9) at ($(8)+(-2,0)$) [state] {$10$};
+    \node[circle, draw=black, thick] (0) at ($(8)+(0,-2)$) [state] {$1$};
+
+    \node[circle, draw=black, thick] (2) at ($(6)+(0,-2)$) [state] {$3$};
+    \node[circle, draw=black, thick] (14) at ($(2)+(2,0)$) [state] {$15$};
+    \node[circle, draw=black, thick] (7) at ($(2)+(0,-2)$) [state] {$8$};
+    \node[circle, draw=black, thick] (10) at ($(14)+(0,-2)$) [state] {$11$};
+    \node[circle, draw=black, thick] (13) at ($(7)+(0,-2)$) [state] {$14$};
+    \node[circle, draw=black, thick] (11) at ($(10)+(0,-2)$) [state] {$12$};
+    \node[circle, draw=black, thick] (15) at ($(11)+(0,-2)$) [state] {$16$};
+
+
+    \coordinate[below of=0] (s);
+
+    \draw (s) edge[out=90, in=-90, ->, thick] node [left] {$C$} (0);
+
+    \draw (0) edge[out=0, in=-90, ->, thick] node [below right] {$C/D$} (13);
+    \draw (0) edge[out=45, in=0, ->, thick] node [above, rotate=90] {$D/D$} (12);
+
+    \draw (1) edge[out=-90, in=0, ->, thick] node [above, yshift=1.3cm, xshift=0.3cm] {$C/D$} (3);
+    \draw (1) edge[out=0, in=180, ->, thick] node [above] {$D/D$} (4);
+
+    \draw (2) edge[out=-45, in=-135, ->, thick] node [above] {$C/D$} (14);
+    \draw (2) edge[out=180, in=90, ->, thick] node [above, yshift=0.8cm, xshift=3cm] {$D/D$} (9);
+
+    \draw (3) edge[out=180, in=-135, ->, thick] node [left, yshift=2cm, xshift=-0.1cm] {$C/C$} (0);
+    \draw (3) edge[out=135, in=180, ->, thick] node [above, yshift=0.2cm] {$D/C$} (1);
+
+    \draw (4) edge[out=90, in=90, ->, thick] node [above] {$C/D$} (1);
+    \draw (4) edge[out=-90, in=0, ->, thick] node [right] {$D/D$} (2);
+
+    \draw (5) edge[out=-90, in=90, ->, thick] node [right, yshift=1cm] {$C/C$} (12);
+    \draw (5) edge[out=0, in=180, ->, thick] node [below right] {$D/C$} (6);
+
+    \draw (6) edge[out=135, in=-45, ->, thick] node [right, xshift=1cm] {$C/C$} (1);
+    \draw (6) edge[out=-45, in=135, ->, thick] node [above left, yshift=-0.5cm] {$D/D$} (14);
+
+    \draw (7) edge[out=135, in=45, ->, thick] node [above] {$C/D$} (12);
+    \draw (7) edge[out=90, in=-90, ->, thick] node [left] {$D/D$} (2);
+
+    \draw (8) edge[out=90, in=-135, ->, thick] node [above right] {$C/D$} (7);
+    \draw (8) edge[out=180, in=0, ->, thick] node [above] {$D/D$} (9);
+
+    \draw (9) edge[out=-45, in=-135, ->, thick] node [below] {$C/D$} (8);
+    \draw (9) edge[out=-90, in=180, ->, thick] node [right] {$D/D$} (0);
+
+    \draw (10) edge[out=180, in=-60, ->, thick] node [below, yshift=-0.5cm, xshift=0.4cm] {$C/C$} (2);
+    \draw (10) edge[out=0, in=0, ->, thick] node [right] {$D/C$} (15);
+
+    \draw (11) edge[out=90, in=-45, ->, thick] node [below right, xshift=0.7cm] {$C/D$} (7);
+    \draw (11) edge[out=180, in=0, ->, thick] node [below] {$D/D$} (13);
+
+    \draw (12) edge[out=135, in=-45, ->, thick] node [above left] {$C/C$} (3);
+    \draw (12) edge[out=-90, in=135, ->, thick] node [left] {$D/D$} (8);
+
+    \draw (13) edge[out=90, in=-90, ->, thick] node [left] {$C/C$} (7);
+    \draw (13) edge[out=45, in=-135, ->, thick] node [below, yshift=-0.2cm, rotate=45] {$D/D$} (10);
+
+    \draw (14) edge[out=-90, in=90, ->, thick] node [right] {$C/D$} (10);
+    \draw (14) edge[out=-100, in=45, ->, thick] node [above] {$D/D$} (7);
+
+    \draw (15) edge[out=-135, in=180, ->, thick, loop] node [left] {$C/C$} (15);
+    \draw (15) edge[out=90, in=-90, ->, thick] node [left] {$D/D$} (11);
+
+
+
+
+    \end{tikzpicture}
+\end{document}

--- a/tex/process_pseudo.tex
+++ b/tex/process_pseudo.tex
@@ -1,0 +1,45 @@
+\documentclass{article}
+\usepackage{algorithm,algorithmic,amsmath}
+
+\begin{document}
+\begin{algorithm}
+\caption{Data Collection}
+  \begin{algorithmic}[1]
+    \FOR{player one \textbf{in} players list}
+      \FOR{player two \textbf{in} (players list - player one)}
+        \STATE pair $\gets$ (player one, player two)
+        \FOR{starting population distributions \textbf{in} [$(1, N-1), (\frac{N}{2}, \frac{N}{2}), (N-1, 1)]$}
+        \WHILE {repetitions $\leq 1000$}
+        \STATE \textbf{simulate} moran process*(pair, starting distribution)        
+        \ENDWHILE
+        \RETURN fixation probabilities      
+        \ENDFOR
+      \ENDFOR
+    \ENDFOR
+  \end{algorithmic}
+\end{algorithm}
+
+\begin{algorithm}
+\caption{Moran process*}
+  \begin{algorithmic}[1]
+  \STATE initial population $\gets$ (pair, starting distribution) \
+  \STATE population $\gets$ initial population
+
+    \WHILE {repetitions $\leq$ max repetitions}
+      \FOR{player in population}
+      \FOR{opponent in (population - player)}
+        \STATE match $\gets$ (player, opponent)
+        \STATE results $\gets$ cache (match) 
+        \ENDFOR
+      \ENDFOR
+      \STATE population $\gets$ sorted(results)
+
+      \STATE parent $\gets$  first in population 
+      \STATE child $\gets$ parent
+      \STATE kill off $\gets$ random player from population
+      \STATE population $\gets$   child replaces kill off
+    \ENDWHILE
+  \end{algorithmic}
+\end{algorithm}
+
+\end{document}


### PR DESCRIPTION
This closes #29 and #28.

The graph representation for the e finite state machines
as described in `players.py`.

Also for representing the process two pieces of pseudocode.
One for the data collection and one for the moran process.

The pseudocodes are in a tex file.

Update gitignore to ignore pdf of tex files.

Ashlock's fortress strategies for comparison are also included

Will also close PR #22. 